### PR TITLE
Fix `{Extend}`+`{Extended_Pictographic}` sequance

### DIFF
--- a/.changeset/clean-fireants-compete.md
+++ b/.changeset/clean-fireants-compete.md
@@ -1,0 +1,10 @@
+---
+"unicode-segmenter": patch
+---
+
+Fix `{Extend}`+`{Extended_Pictographic}` sequence
+
+Counterexample:
+- '👩‍🦰👩‍👩‍👦‍👦🏳️‍🌈' -> 3 graphemes
+
+Reported from https://github.com/eslint/eslint/pull/18359

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Look [benchmark](benchmark) to see how it works.
 
   | Name                         | ESM? | Size    | Size (min)       | Size (min+gzip)  | Size (min+br)    |
   |------------------------------|------|--------:|-----------------:|-----------------:|-----------------:|
-  | `unicode-segmenter/grapheme` |    ✔️ |  44,892 |           30,081 |            9,299 |            5,907 |
+  | `unicode-segmenter/grapheme` |    ✔️ |  44,913 |           30,090 |            9,304 |            5,995 |
   | `graphemer`                  |    ✖️ ️| 410,424 |           95,104 |           15,752 |           10,660 |
   | `grapheme-splitter`          |    ✖️ | 122,241 |           23,680 |            7,852 |            4,841 |
 

--- a/src/grapheme.js
+++ b/src/grapheme.js
@@ -125,7 +125,10 @@ export function* graphemeSegments(input) {
       catAfter = categoryOf(cp);
     }
 
-    if (catBefore === 4 /* Extended_Pictographic */ && catAfter === 14 /* ZWJ */) {
+    if (
+      (catBefore === 3 /* Extend */ || catBefore === 4 /* Extended_Pictographic */)
+      && catAfter === 14 /* ZWJ */
+    ) {
       // begin emoji sequance
       emoji = true;
     }
@@ -133,6 +136,7 @@ export function* graphemeSegments(input) {
     if (isBoundary(catBefore, catAfter)) {
       yield { segment, index, input, _cat: catBefore };
 
+      // flush
       index = cursor;
       segment = '';
       emoji = false;

--- a/test/grapheme.js
+++ b/test/grapheme.js
@@ -151,6 +151,7 @@ test('counter examples', async t => {
     '‍◻',
     '🇷‍◻',
     '🇷🇸A',
+    '👩‍🦰👩‍👩‍👦‍👦🏳️‍🌈',
   ];
 
   for (let counter of counterExamples) {


### PR DESCRIPTION
Counterexample:
- `👩‍🦰👩‍👩‍👦‍👦🏳️‍🌈` -> 3 graphemes

Reported from https://github.com/eslint/eslint/pull/18359