### PR TITLE
remove bundle entrypoints from the package

### DIFF
--- a/.changeset/big-rats-occur.md
+++ b/.changeset/big-rats-occur.md
@@ -1,0 +1,5 @@
+---
+"unicode-segmenter": minor
+---
+
+Remove pre-built bundled entrypoints from the package

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
         "import": "./intl-polyfill.js",
         "require": "./intl-polyfill.cjs"
       },
-      "./bundle/*": "./bundle/*.js",
       "./package.json": "./package.json"
     }
   },
@@ -87,12 +86,11 @@
     "/*.cjs",
     "/*.d.ts",
     "/*.d.cts",
-    "/licenses",
-    "/bundle"
+    "/licenses"
   ],
   "scripts": {
     "prepack": "yarn clean && yarn build",
-    "clean": "rimraf -g \"*.js\" \"*.cjs\" \"*.map\" \"*.d.ts\" \"*.d.cts\" \"bundle\"",
+    "clean": "rimraf -g \"*.js\" \"*.cjs\" \"*.map\" \"*.d.ts\" \"*.d.cts\"",
     "build": "node scripts/build-exports.js",
     "test": "node --test --test-reporter spec --test-reporter-destination=stdout",
     "test:coverage": "yarn test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info",

--- a/scripts/build-exports.js
+++ b/scripts/build-exports.js
@@ -73,40 +73,6 @@ function rewriteCjs(content) {
   // );
 }
 
-{
-  console.log('Build browser bundles...');
-
-  let bundleEntryPoints = [
-    src('index.js'),
-    src('emoji.js'),
-    src('general.js'),
-    src('grapheme.js'),
-    src('intl-adapter.js'),
-    src('intl-polyfill.js'),
-  ];
-  await build({
-    bundle: true,
-    entryPoints: bundleEntryPoints,
-    outdir: bundleDir,
-    outExtension: { '.js': '.js' },
-    format: 'esm',
-    treeShaking: true,
-    write: true,
-    sourcemap: false,
-  });
-  await build({
-    bundle: true,
-    entryPoints: bundleEntryPoints,
-    outdir: bundleDir,
-    outExtension: { '.js': '.min.js' },
-    format: 'esm',
-    minify: true,
-    treeShaking: true,
-    write: true,
-    sourcemap: false,
-  });
-}
-
 if (!process.argv.includes('--no-tsc')) {
   console.log('Building type declarations...');
   const { promise, resolve, reject } = Promise.withResolvers();


### PR DESCRIPTION
The previous version provides pre-built "bundled" endpoints. 

I did it because I found use cases for it, such as the WeChat mini-programs project. However, I changed my mind. Many node_modules were inflated (like ~240KB) for very limited use cases.

Users can still load unbundled ESM modules directly in the browser and, if necessary, use the bundler at any time.