### PR TITLE
reset consonant state on boundary emit

### DIFF
--- a/.changeset/heavy-clouds-walk.md
+++ b/.changeset/heavy-clouds-walk.md
@@ -1,0 +1,16 @@
+---
+"unicode-segmenter": patch
+---
+
+Fix GB9c rule; reset internal "InCB=Consonant" state properly.
+
+So giving the following input:
+
+```
+# Malayalam KA + Virama + SPACE + VA
+"क्‌ क"
+```
+
+Will now produces three sperated segments correctly.
+
+Thanks to @spaceemotion for reporting this issue.

--- a/src/grapheme.js
+++ b/src/grapheme.js
@@ -150,6 +150,7 @@ export function* graphemeSegments(input) {
 
       // Reset segment state
       emoji = false;
+      consonant = false;
       riCount = 0;
       index = cursor;
       _catBegin = catAfter;

--- a/test/grapheme.js
+++ b/test/grapheme.js
@@ -307,6 +307,7 @@ test('counterexamples', async t => {
     ' जा',
     ' କା',
     ' ଶ୍ୟା',
+    'ക് വ',
   ];
 
   for (let counter of counterExamples) {


### PR DESCRIPTION
Also reported from #124

I was aware this would definitely be a problem, but I passed it so naively. The state reset cannot be skipped.